### PR TITLE
Add Laravel/Filament flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
 
     # PHP subflakes
     php.url       = "github:4Gettt25/flakes?dir=php";
+    logbookPhp.url = "github:4Gettt25/flakes?dir=php/logbook-php";
   };
 
   outputs = { 
@@ -21,6 +22,7 @@
     flake-utils,
     python310,
     php,
+    logbookPhp,
     python313,
     ...
     }:
@@ -45,6 +47,9 @@
 
         # PHP
         devShells.php       = php.devShells.${system}.default;
+        devShells."logbook-php" = logbookPhp.devShells.${system}.default;
+
+        packages."logbook-php" = logbookPhp.packages.${system}.default;
       }
     );
 }

--- a/php/logbook-php/flake.nix
+++ b/php/logbook-php/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Laravel + Filament PHP project environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        packages.default = pkgs.buildEnv {
+          name = "logbook-php-env";
+          paths = [
+            pkgs.php83
+            pkgs.php83Packages.composer
+            pkgs.nodejs_20
+            # Framework tooling
+            pkgs.php83Packages.laravel
+            pkgs.php83Packages.filament
+          ];
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.php83
+            pkgs.php83Packages.composer
+            pkgs.nodejs_20
+            pkgs.php83Packages.laravel
+            pkgs.php83Packages.filament
+          ];
+          shellHook = ''
+            export NIX_CONFIG="experimental-features = nix-command flakes"
+            echo "Entering Laravel + Filament development shell"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- add a dedicated logbook-php flake with PHP 8.3, composer and Node
- expose new logbook-php devShell and package from the root flake
- include the Laravel and Filament packages in logbook-php

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68405f81a098832ebca881aff6dd2a99